### PR TITLE
Fix bug in PUT env-vars endpoint API schema

### DIFF
--- a/provider/cmd/pulumi-resource-render/openapi_generated.yml
+++ b/provider/cmd/pulumi-resource-render/openapi_generated.yml
@@ -4046,7 +4046,11 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/envVarInputArray'
+                            properties:
+                                envVars:
+                                    type: array
+                                    items:
+                                        $ref: '#/components/schemas/envVarInput'
             responses:
                 "200":
                     description: OK

--- a/provider/pkg/gen/openapi_fixes.go
+++ b/provider/pkg/gen/openapi_fixes.go
@@ -68,9 +68,10 @@ func fixEnvVarsPutEndpoint(openAPIDoc *openapi3.T) error {
 
 	reqBodySchema := pathItem.Put.RequestBody.Value.Content.Get(jsonMimeType)
 	originalSchema := reqBodySchema.Schema.Value
-	reqBodySchema.Schema.Value = openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
+	schema := openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
 		"envVars": originalSchema,
 	})
+	reqBodySchema.Schema = openapi3.NewSchemaRef("", schema)
 
 	return nil
 }

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -268,6 +268,8 @@ func (p *renderProvider) OnPreUpdate(_ context.Context, req *pulumirpc.UpdateReq
 		return nil
 	}
 
+	logging.V(3).Infof("OnePreUpdate: Modifying request body for %s", envVarResourceTypeToken)
+
 	body, err := io.ReadAll(httpReq.Body)
 	if err != nil {
 		return errors.Wrapf(err, "reading body in OnPreUpdate while handling %s", resourceTypeToken)


### PR DESCRIPTION
Looks like the API fix didn't apply properly because the change to the OpenAPI schema object didn't serialize in the OpenAPI doc that is embedded into the provider.